### PR TITLE
fix: avoid ephemeral version guard

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ resource "azapi_resource" "this_environment" {
       "properties.daprAIInstrumentationKey"                                                      = var.dapr_ai_instrumentation_key_version
       "properties.openTelemetryConfiguration.destinationsConfiguration.dataDogConfiguration.key" = var.key_version
     },
-    local.effective_app_logs_configuration != null && local.effective_app_logs_configuration.destination == "log-analytics" && var.shared_key != null ? {
+    local.effective_app_logs_configuration != null && local.effective_app_logs_configuration.destination == "log-analytics" && var.shared_key_version != null ? {
       "properties.appLogsConfiguration.logAnalyticsConfiguration.sharedKey" = var.shared_key_version
     } : {}
   )


### PR DESCRIPTION
## Description

This follow-up fixes a regression introduced in the previous TFLint PR. The `sensitive_body_version` map was guarded with `var.shared_key != null`, which made the expression depend on an ephemeral value and caused Terraform to reject the resource configuration.

This change switches that guard to `var.shared_key_version != null`, preserving the intended version-tracking behavior for the explicit shared-key path without leaking ephemeral state into a persisted attribute.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks